### PR TITLE
feat: Add configSetting state resource.

### DIFF
--- a/lib/plugin/components/state-resources/config-setting/doc/example.json
+++ b/lib/plugin/components/state-resources/config-setting/doc/example.json
@@ -1,0 +1,11 @@
+{
+  "ReadEmailHost": {
+    "Type": "Task",
+    "Resource": "module:configSetting",
+    "ResourceConfig": {
+      "setting": "email.server.hostname"
+    },
+    "ResultPath": "$.server",
+    "End": true
+  }
+}

--- a/lib/plugin/components/state-resources/config-setting/doc/index.js
+++ b/lib/plugin/components/state-resources/config-setting/doc/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  description: 'Reads a config setting',
+  example: require('./example.json')
+}

--- a/lib/plugin/components/state-resources/config-setting/index.js
+++ b/lib/plugin/components/state-resources/config-setting/index.js
@@ -1,0 +1,14 @@
+const dottie = require('dottie')
+
+module.exports = class ConfigSetting {
+  init (resourceConfig, env) {
+    this.setting = dottie.get(
+      env.config,
+      resourceConfig.setting
+    )
+  }
+
+  run (event, context) {
+    context.sendTaskSuccess(this.setting)
+  } // run
+} // ConfigSetting

--- a/lib/plugin/components/state-resources/config-setting/schema.j2119
+++ b/lib/plugin/components/state-resources/config-setting/schema.j2119
@@ -1,0 +1,2 @@
+This document specifies a JSON object called a "ConfigSetting Resource Config".
+A ConfigSetting Resource Config MUST have a string field named "setting".

--- a/test/config-setting-state-resource-tests.js
+++ b/test/config-setting-state-resource-tests.js
@@ -1,0 +1,57 @@
+/* eslint-env mocha */
+
+const path = require('path')
+const expect = require('chai').expect
+const tymly = require('../lib')
+
+describe('Config Setting state resources', function () {
+  this.timeout(process.env.TIMEOUT || 5000)
+
+  let tymlyService
+  let statebox
+
+  it('boot Tymly', async () => {
+    const services = await tymly.boot(
+      {
+        blueprintPaths: [
+          path.resolve(__dirname, './fixtures/blueprints/config-setting-blueprint')
+        ],
+        pluginPaths: [
+          path.resolve(__dirname, '../node_modules/@wmfs/tymly-test-helpers/plugins/allow-everything-rbac-plugin')
+        ],
+        config: {
+          values: {
+            string: 'good',
+            integer: 123,
+            bool: true
+          }
+        }
+      }
+    )
+
+    tymlyService = services.tymly
+    statebox = services.statebox
+  })
+
+  const goodTests = [
+    [ 'string', 'good' ],
+    [ 'integer', 123 ],
+    [ 'bool', true ],
+    [ 'unspecified', undefined ]
+  ]
+
+  for (const [name, expected] of goodTests) {
+    it(`fetch ${name} config setting`, async () => {
+      const execDesc = await statebox.startExecution(
+        {},
+        `tymlyTest_${name}ConfigSetting_1_0`,
+        { sendResponse: 'COMPLETE' }
+      )
+      expect(execDesc.ctx.setting).to.eql(expected)
+    })
+  }
+
+  it('shutdown Tymly', async () => {
+    await tymlyService.shutdown()
+  })
+})

--- a/test/fixtures/blueprints/config-setting-blueprint/blueprint.json
+++ b/test/fixtures/blueprints/config-setting-blueprint/blueprint.json
@@ -1,0 +1,9 @@
+{
+
+  "namespace": "tymlyTest",
+  "name": "config-setting",
+  "version": "1.0",
+
+  "label": "Config Setting",
+  "organisation": "Tymly"
+}

--- a/test/fixtures/blueprints/config-setting-blueprint/state-machines/boolConfigSetting.json
+++ b/test/fixtures/blueprints/config-setting-blueprint/state-machines/boolConfigSetting.json
@@ -1,0 +1,24 @@
+{
+  "Comment": "Blueprint to get bool config variable",
+  "version": "1.0",
+  "StartAt": "Config",
+  "States": {
+    "Config": {
+      "Type": "Task",
+      "Resource": "module:configSetting",
+      "ResourceConfig": {
+        "setting": "values.bool"
+      },
+      "ResultPath": "$.setting",
+      "End": true
+    }
+  },
+  "restrictions": [
+    {
+      "roleId": "$authenticated",
+      "allows": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/test/fixtures/blueprints/config-setting-blueprint/state-machines/integerConfigSetting.json
+++ b/test/fixtures/blueprints/config-setting-blueprint/state-machines/integerConfigSetting.json
@@ -1,0 +1,24 @@
+{
+  "Comment": "Blueprint to get integer config variable",
+  "version": "1.0",
+  "StartAt": "Config",
+  "States": {
+    "Config": {
+      "Type": "Task",
+      "Resource": "module:configSetting",
+      "ResourceConfig": {
+        "setting": "values.integer"
+      },
+      "ResultPath": "$.setting",
+      "End": true
+    }
+  },
+  "restrictions": [
+    {
+      "roleId": "$authenticated",
+      "allows": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/test/fixtures/blueprints/config-setting-blueprint/state-machines/stringConfigSetting.json
+++ b/test/fixtures/blueprints/config-setting-blueprint/state-machines/stringConfigSetting.json
@@ -1,0 +1,24 @@
+{
+  "Comment": "Blueprint to get string config variable",
+  "version": "1.0",
+  "StartAt": "Config",
+  "States": {
+    "Config": {
+      "Type": "Task",
+      "Resource": "module:configSetting",
+      "ResourceConfig": {
+        "setting": "values.string"
+      },
+      "ResultPath": "$.setting",
+      "End": true
+    }
+  },
+  "restrictions": [
+    {
+      "roleId": "$authenticated",
+      "allows": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/test/fixtures/blueprints/config-setting-blueprint/state-machines/unspecifiedConfigSetting.json
+++ b/test/fixtures/blueprints/config-setting-blueprint/state-machines/unspecifiedConfigSetting.json
@@ -1,0 +1,24 @@
+{
+  "Comment": "Blueprint to get a config variable",
+  "version": "1.0",
+  "StartAt": "Config",
+  "States": {
+    "Config": {
+      "Type": "Task",
+      "Resource": "module:configSetting",
+      "ResourceConfig": {
+        "setting": "values.unspecified"
+      },
+      "ResultPath": "$.setting",
+      "End": true
+    }
+  },
+  "restrictions": [
+    {
+      "roleId": "$authenticated",
+      "allows": [
+        "*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Reads a single config value and adds it to the execution context. The config value is read at start
time, and so will not reflect any runtime shenanighans with the config object.