### PR TITLE
fix: Memory model where equals: can take an array

### DIFF
--- a/lib/plugin/components/services/storage/Memory-model.js
+++ b/lib/plugin/components/services/storage/Memory-model.js
@@ -146,8 +146,14 @@ class MemoryModel {
 
               switch (conditionType) {
                 case 'equals':
-                  if (row[propertyId] !== expression) {
-                    matches = false
+                  if (Array.isArray(expression)) {
+                    if (!expression.includes(row[propertyId])) {
+                      matches = false
+                    }
+                  } else {
+                    if (row[propertyId] !== expression) {
+                      matches = false
+                    }
                   }
                   break
                 case 'moreThan':

--- a/test/memory-model-promise-spec.js
+++ b/test/memory-model-promise-spec.js
@@ -237,6 +237,31 @@ describe('Memory Model promise tests', function () {
     )
   })
 
+  it('find Bart or Homer by name', async () => {
+    const doc = await personModel.findOne(
+      {
+        where: {
+          firstName: { equals: ['Homer', 'Bart'] },
+          lastName: { equals: 'Simpson' }
+        }
+      }
+    )
+    expect(doc).to.containSubset(
+      {
+        age: 39,
+        employeeNo: 1,
+        firstName: 'Homer',
+        lastName: 'Simpson'
+      },
+      {
+        age: 10,
+        employeeNo: 5,
+        firstName: 'Bart',
+        lastName: 'Simpson'
+      }
+    )
+  })
+
   it("shouldn't get one missing person", async () => {
     const doc = await personModel.findOne(
       {


### PR DESCRIPTION
Selects rows where the property has any value in the array. This brings it into line with the
behaviour implemented by the pg models.