### PR TITLE
Inventory service remove callbacks

### DIFF
--- a/lib/boot/boot/index.js
+++ b/lib/boot/boot/index.js
@@ -46,6 +46,8 @@ function bootService (serviceComponent, options, config, messages, bootedService
 
   bootedServices[serviceComponent.name] = service
 
+  if (!service.boot) return
+
   const hasCallback = service.boot.length === 2
 
   if (hasCallback) {

--- a/lib/plugin/components/services/inventory/index.js
+++ b/lib/plugin/components/services/inventory/index.js
@@ -28,75 +28,52 @@ class InventoryService {
    * )
    */
   collateEverything (options, callback) {
-    let inventory = {
+    const inventory = {
       generated: new Date(),
-      plugins: {}
+      plugins: findPlugins(options)
     }
 
-    // Use the main loadDir module to gather plugin-things
-    // ---------------------------------------------------
-    const pluginPaths = pathExploder(
-      options.pluginPaths,
-      { suffix: 'components', expectModule: true }
-    )
+    arrangeByComponentType(inventory)
 
-    pluginPaths.forEach(
-      function (pluginPath) {
-        const meta = require(path.resolve(pluginPath, './..'))
-
-        const pluginInfo = {
-          pluginPath: pluginPath,
-          meta: meta,
-          components: {}
-        }
-
-        loadDir(
-          pluginPath,
-          pluginInfo.components,
-          { },
-          {
-            includeDocumentation: true,
-            quiet: false,
-            messages: options.messages
-          }
-        )
-        inventory.plugins[pluginPath] = pluginInfo
-      }
-    )
-
-    // Get rid of functions
-    // --------------------
-    inventory = JSON.parse(JSON.stringify(inventory))
-    pruneFunctions(inventory)
-
-    // Duplicate things by component type
-    // ----------------------------------
-
-    // Loop over all plugins
-    for (const [pluginId, plugin] of Object.entries(inventory.plugins)) {
-      plugin.package = readPkgUp.sync({ cwd: plugin.pluginPath })
-      if (Object.prototype.hasOwnProperty.call(plugin, 'components')) {
-        // Loop over all component types
-        for (const [componentTypeName, componentType] of Object.entries(plugin.components)) {
-          // Add component type if its not there already
-          if (!Object.prototype.hasOwnProperty.call(inventory, componentTypeName)) {
-            inventory[componentTypeName] = {}
-          }
-
-          // Loop over all components
-          for (const [componentId, component] of Object.entries(componentType)) {
-            if (!Object.prototype.hasOwnProperty.call(inventory[componentTypeName], componentId)) {
-              inventory[componentTypeName][componentId] = []
-            }
-            component.pluginId = pluginId
-            inventory[componentTypeName][componentId].push(component)
-          }
-        }
-      }
-    }
-    callback(null, inventory)
+    return inventory
   }
 } // class InventoryService
+
+function findPlugins (options) {
+  const plugins = { }
+
+  // Use the main loadDir module to gather plugin-things
+  // ---------------------------------------------------
+  const pluginPaths = pathExploder(
+    options.pluginPaths,
+    { suffix: 'components', expectModule: true }
+  )
+
+  pluginPaths.forEach(pluginPath => {
+    const meta = require(path.resolve(pluginPath, './..'))
+
+    const pluginInfo = {
+      pluginPath: pluginPath,
+      meta: meta,
+      components: {}
+    }
+
+    loadDir(
+      pluginPath,
+      pluginInfo.components,
+      { },
+      {
+        includeDocumentation: true,
+        quiet: false,
+        messages: options.messages
+      }
+    )
+
+    plugins[pluginPath] = pluginInfo
+  })
+
+  return pruneFunctions(JSON.parse(JSON.stringify(plugins)))
+} // findPlugins
 
 function pruneFunctions (rootValue) {
   if (_.isArray(rootValue)) {
@@ -110,12 +87,38 @@ function pruneFunctions (rootValue) {
       }
     } // for ...
   } // else
+
+  return rootValue
 } // pruneFunctions
 
+function arrangeByComponentType (inventory) {
+  // Duplicate things by component type
+  // ----------------------------------
+  for (const [pluginId, plugin] of Object.entries(inventory.plugins)) {
+    plugin.package = readPkgUp.sync({ cwd: plugin.pluginPath })
+    if (!Object.prototype.hasOwnProperty.call(plugin, 'components')) {
+      continue // no components in this plugin
+    }
 
+    for (const [componentTypeName, componentType] of Object.entries(plugin.components)) {
+      // Add component type if its not there already
+      if (!Object.prototype.hasOwnProperty.call(inventory, componentTypeName)) {
+        inventory[componentTypeName] = {}
+      }
+
+      // Loop over all components
+      for (const [componentId, component] of Object.entries(componentType)) {
+        if (!Object.prototype.hasOwnProperty.call(inventory[componentTypeName], componentId)) {
+          inventory[componentTypeName][componentId] = []
+        }
+        component.pluginId = pluginId
+        inventory[componentTypeName][componentId].push(component)
+      }
+    }
+  } // for plugins ...
+} // arrangeByComponentType
 
 module.exports = {
   serviceClass: InventoryService,
   bootBefore: ['storage']
-
 }

--- a/lib/plugin/components/services/inventory/index.js
+++ b/lib/plugin/components/services/inventory/index.js
@@ -7,20 +7,6 @@ const pathExploder = require('./../../../../boot/load/tymly-loader/path-exploder
 const readPkgUp = require('read-pkg-up')
 
 class InventoryService {
-  pruneFunctions (rootValue) {
-    if (_.isArray(rootValue)) {
-      rootValue.forEach(element => this.pruneFunctions(element))
-    } else if (_.isObject(rootValue)) {
-      for (const [key, value] of Object.entries(rootValue)) {
-        if (_.isFunction(value)) {
-          delete rootValue[key]
-        } else if (_.isObject(value)) {
-          this.pruneFunctions(value)
-        }
-      } // for ...
-    } // else
-  } // pruneFunctions
-
   /**
    * Scan the supplied plugin-paths and extract all manner of information for subsequent use by tooling and doc-generators.
    * @param {Object} options
@@ -49,7 +35,10 @@ class InventoryService {
 
     // Use the main loadDir module to gather plugin-things
     // ---------------------------------------------------
-    const pluginPaths = pathExploder(options.pluginPaths, { suffix: 'components', expectModule: true })
+    const pluginPaths = pathExploder(
+      options.pluginPaths,
+      { suffix: 'components', expectModule: true }
+    )
 
     pluginPaths.forEach(
       function (pluginPath) {
@@ -78,7 +67,7 @@ class InventoryService {
     // Get rid of functions
     // --------------------
     inventory = JSON.parse(JSON.stringify(inventory))
-    this.pruneFunctions(inventory)
+    pruneFunctions(inventory)
 
     // Duplicate things by component type
     // ----------------------------------
@@ -107,7 +96,23 @@ class InventoryService {
     }
     callback(null, inventory)
   }
-}
+} // class InventoryService
+
+function pruneFunctions (rootValue) {
+  if (_.isArray(rootValue)) {
+    rootValue.forEach(element => pruneFunctions(element))
+  } else if (_.isObject(rootValue)) {
+    for (const [key, value] of Object.entries(rootValue)) {
+      if (_.isFunction(value)) {
+        delete rootValue[key]
+      } else if (_.isObject(value)) {
+        pruneFunctions(value)
+      }
+    } // for ...
+  } // else
+} // pruneFunctions
+
+
 
 module.exports = {
   serviceClass: InventoryService,

--- a/lib/plugin/components/services/inventory/index.js
+++ b/lib/plugin/components/services/inventory/index.js
@@ -7,9 +7,6 @@ const pathExploder = require('./../../../../boot/load/tymly-loader/path-exploder
 const readPkgUp = require('read-pkg-up')
 
 class InventoryService {
-  boot () {
-  }
-
   pruneFunctions (rootValue) {
     if (_.isArray(rootValue)) {
       rootValue.forEach(element => this.pruneFunctions(element))

--- a/lib/plugin/components/services/inventory/index.js
+++ b/lib/plugin/components/services/inventory/index.js
@@ -27,7 +27,7 @@ class InventoryService {
    *   }
    * )
    */
-  collateEverything (options, callback) {
+  collateEverything (options) {
     const inventory = {
       generated: new Date(),
       plugins: findPlugins(options)

--- a/test/inventory-spec.js
+++ b/test/inventory-spec.js
@@ -24,20 +24,18 @@ describe('Inventory tests', function () {
     inventoryService = tymlyServices.inventory
   })
 
-  it('return inventory contents', function (done) {
-    inventoryService.collateEverything(
+  it('inventory contents', () => {
+    const inventory = inventoryService.collateEverything(
       {
         blueprintPaths: blueprintPaths,
         pluginPaths: pluginPaths,
         messages: startupMessages()
-      },
-      function (err, inventory) {
-        expect(err).to.eql(null)
-        expect(inventory).to.be.an('object')
-        expect(inventory.states.purring).to.be.an('array')
-        done()
       }
     )
+
+    expect(inventory).to.be.an('object')
+    expect(Object.keys(inventory.plugins)).to.have.length(1)
+    expect(inventory.states.purring).to.be.an('array')
   })
 
   after('shutdown Tymly', async () => {


### PR DESCRIPTION
Moving inventory service away from callback style, because it doesn't need to be :)

Inventory service isn't used outside tymly-core, so this is a nice easy one. 