### PR TITLE
Memory model promise first

### DIFF
--- a/lib/plugin/components/services/storage/Memory-model.js
+++ b/lib/plugin/components/services/storage/Memory-model.js
@@ -203,12 +203,11 @@ class MemoryModel {
   }
 
   // TODO: Options! limit/offset etc.
-  find (options, callback = NotSet) {
-    if (callback === NotSet) {
-      return this.promised(this.find, options)
+  async find (options, callback = NotSet) {
+    if (callback !== NotSet) {
+      return callbackify(this.find(options), callback)
     }
-    const output = this.applyWhere(options).map(_.cloneDeep)
-    callback(null, output)
+    return this.applyWhere(options).map(_.cloneDeep)
   }
 
   turnIdIntoWhere (id) {

--- a/lib/plugin/components/services/storage/Memory-model.js
+++ b/lib/plugin/components/services/storage/Memory-model.js
@@ -328,9 +328,9 @@ class MemoryModel {
     callback(null)
   }
 
-  upsert (doc, options, callback = NotSet) {
-    if (callback === NotSet) {
-      return this.promised(this.upsert, doc, options)
+  async upsert (doc, options, callback = NotSet) {
+    if (callback !== NotSet) {
+      return callbackify(this.upsert(doc, options), callback)
     }
 
     const whereProperties = this.extractIdPropertiesFromDoc(doc)
@@ -342,13 +342,8 @@ class MemoryModel {
       }
 
       this.data[index] = _.cloneDeep(doc)
-      callback(null)
     } else {
-      this.create(
-        doc,
-        options,
-        callback
-      )
+      return this.create(doc, options)
     }
   }
 

--- a/lib/plugin/components/services/storage/Memory-model.js
+++ b/lib/plugin/components/services/storage/Memory-model.js
@@ -236,32 +236,27 @@ class MemoryModel {
   }
 
   findById (id, callback = NotSet) {
-    if (callback === NotSet) {
-      return this.promised(this.findById, id)
+    if (callback !== NotSet) {
+      return callbackify(this.findById(id), callback)
     }
-    if (!_.isArray(id)) {
+    if (!Array.isArray(id)) {
       id = [id]
     }
 
-    this.findOne(
-      {
-        where: this.turnIdIntoWhere(id)
-      },
-      callback
-    )
+    return this.findOne({
+      where: this.turnIdIntoWhere(id)
+    })
   }
 
-  findOne (options, callback = NotSet) {
-    if (callback === NotSet) {
-      return this.promised(this.findOne, options)
+  async findOne (options, callback = NotSet) {
+    if (callback !== NotSet) {
+      return callbackify(this.findOne(options), callback)
     }
 
-    let doc
     const output = this.applyWhere(options)
     if (output.length > 0) {
-      doc = _.cloneDeep(output[0])
+      return _.cloneDeep(output[0])
     }
-    callback(null, doc)
   }
 
   findFirstIndex (whereProperties) {

--- a/lib/plugin/components/services/storage/Memory-model.js
+++ b/lib/plugin/components/services/storage/Memory-model.js
@@ -14,18 +14,6 @@ function callbackify (promise, callback) {
     .catch(err => callback(err))
 }
 
-function promised (obj, fn, ...args) {
-  return new Promise((resolve, reject) => {
-    fn.call(obj, ...args, (err, result) => {
-      if (err) {
-        reject(err)
-      } else {
-        resolve(result)
-      }
-    })
-  })
-} // promised
-
 const CREATED_BY = 'createdBy'
 const MODIFIED_BY = 'modifiedBy'
 
@@ -46,7 +34,6 @@ class MemoryModel {
       this.primaryKey = ['id']
     }
 
-    this.promised = (...args) => promised(this, ...args)
     this.currentUser = (service && service.currentUser) ? () => service.currentUser() : () => null
   }
 

--- a/lib/plugin/components/services/storage/Memory-model.js
+++ b/lib/plugin/components/services/storage/Memory-model.js
@@ -25,7 +25,7 @@ class MemoryModel {
 
     this.modelId = modelDefinition.id
     this.data = []
-    this.primaryKeyProvided = _.isArray(modelDefinition.primaryKey)
+    this.primaryKeyProvided = Array.isArray(modelDefinition.primaryKey)
     this.properties = modelDefinition.properties
 
     if (this.primaryKeyProvided) {
@@ -100,69 +100,27 @@ class MemoryModel {
   }
 
   applyWhere (options) {
-    const _this = this
     if (Object.prototype.hasOwnProperty.call(options, 'where')) {
-      const filtered = []
+      const filtered = this.data
+        .map(row => {
+          const conditions = Object.entries(options.where)
+          const matches = conditions
+            .map(([propertyId, condition]) => {
+              const conditionType = Object.keys(condition)[0]
+              const expression = Object.values(condition)[0]
 
-      this.data.forEach(
-        function (row) {
-          let matches = true
+              return evaluateExpression(row[propertyId], conditionType, expression)
+            })
+            .filter(match => match)
+            .length === conditions.length
 
-          _.forOwn(
-            options.where,
-            function (condition, propertyId) {
-              const conditionType = _.keys(condition)[0]
-              const expression = _.values(condition)[0]
+          return matches ? row : null
+        })
+        .filter(row => row)
 
-              switch (conditionType) {
-                case 'equals':
-                  if (Array.isArray(expression)) {
-                    if (!expression.includes(row[propertyId])) {
-                      matches = false
-                    }
-                  } else {
-                    if (row[propertyId] !== expression) {
-                      matches = false
-                    }
-                  }
-                  break
-                case 'moreThan':
-                  if (!(row[propertyId] > expression)) {
-                    matches = false
-                  }
-                  break
-                case 'lessThan':
-                  if (!(row[propertyId] < expression)) {
-                    matches = false
-                  }
-                  break
-                case 'moreThanEquals':
-                  if (!(row[propertyId] >= expression)) {
-                    matches = false
-                  }
-                  break
-                case 'lessThanEquals':
-                  if (!(row[propertyId] <= expression)) {
-                    matches = false
-                  }
-                  break
-                case 'like':
-                  if (!(row[propertyId].includes(expression))) {
-                    matches = false
-                  }
-                  break
-              }
-            }
-          )
-
-          if (matches) {
-            filtered.push(row)
-          }
-        }
-      )
-      return _this.applyModifiers(filtered, options)
+      return this.applyModifiers(filtered, options)
     } else {
-      return _this.applyModifiers(this.data, options)
+      return this.applyModifiers(this.data, options)
     }
   }
 
@@ -176,25 +134,17 @@ class MemoryModel {
 
   turnIdIntoWhere (id) {
     const where = {}
-    let i = -1
-    this.primaryKey.forEach(
-      function (propertyId) {
-        i++
-        where[propertyId] = { equals: id[i] }
-      }
-    )
+    this.primaryKey.forEach((propertyId, index) => {
+      where[propertyId] = { equals: id[index] }
+    })
     return where
   }
 
   turnIdIntoProperties (id) {
     const properties = {}
-    let i = -1
-    this.primaryKey.forEach(
-      function (propertyId) {
-        i++
-        properties[propertyId] = id[i]
-      }
-    )
+    this.primaryKey.forEach((propertyId, index) => {
+      properties[propertyId] = id[index]
+    })
     return properties
   }
 
@@ -223,32 +173,24 @@ class MemoryModel {
   }
 
   findFirstIndex (whereProperties) {
-    let index = -1
+    let index = 0
 
-    let i = -1
-    this.data.forEach(
-      function (row) {
-        i++
+    for (const row of this.data) {
+      let matches = true
 
-        if (index === -1) {
-          let matches = true
+      Object.entries(whereProperties)
+        .forEach(([propertyId, value]) => {
+          matches = matches && (value === row[propertyId])
+        })
 
-          _.forOwn(
-            whereProperties,
-            function (value, propertyId) {
-              if (value !== row[propertyId]) {
-                matches = false
-              }
-            }
-          )
-
-          if (matches) {
-            index = i
-          }
-        }
+      if (matches) {
+        return index
       }
-    )
-    return index
+
+      ++index
+    }
+
+    return -1
   }
 
   async update (doc, options, callback = NotSet) {
@@ -328,6 +270,48 @@ class MemoryModelError extends Error {
     super(message)
     this.name = name
   }
+}
+
+function evaluateExpression (value, conditionType, expression) {
+  switch (conditionType) {
+    case 'equals':
+      if (Array.isArray(expression)) {
+        if (!expression.includes(value)) {
+          return false
+        }
+      } else {
+        if (value !== expression) {
+          return false
+        }
+      }
+      break
+    case 'moreThan':
+      if (!(value > expression)) {
+        return false
+      }
+      break
+    case 'lessThan':
+      if (!(value < expression)) {
+        return false
+      }
+      break
+    case 'moreThanEquals':
+      if (!(value >= expression)) {
+        return false
+      }
+      break
+    case 'lessThanEquals':
+      if (!(value <= expression)) {
+        return false
+      }
+      break
+    case 'like':
+      if (!(value.includes(expression))) {
+        return false
+      }
+      break
+  }
+  return true
 }
 
 module.exports = MemoryModel

--- a/lib/plugin/components/services/storage/Memory-model.js
+++ b/lib/plugin/components/services/storage/Memory-model.js
@@ -61,60 +61,37 @@ class MemoryModel {
     return properties
   }
 
-  create (jsonData, options, callback = NotSet) {
-    if (callback === NotSet) {
-      return this.promised(this.create, jsonData, options)
+  async create (jsonData, options, callback = NotSet) {
+    if (callback !== NotSet) {
+      return callbackify(this.create(jsonData, options), callback)
     }
 
-    const _this = this
-    let idProperties
-    let err = null
+    jsonData = Array.isArray(jsonData) ? jsonData : [jsonData]
 
-    function createOne (doc) {
-      const whereProperties = _this.extractIdPropertiesFromDoc(doc)
-      const index = _this.findFirstIndex(whereProperties)
+    return jsonData.map(jd => this.createOne(jd))[0]
+  }
 
-      if (index === -1) {
-        const copy = _.cloneDeep(doc)
-        if (!_this.primaryKeyProvided) {
-          copy.id = uuid()
-        }
-        //        copy.created = now
-        //        copy.updated = now
-        copy[CREATED_BY] = _this.currentUser()
-        _this.data.push(copy)
+  createOne (doc) {
+    const whereProperties = this.extractIdPropertiesFromDoc(doc)
+    const index = this.findFirstIndex(whereProperties)
 
-        if (!idProperties) {
-          idProperties = _this.extractIdPropertiesFromDoc(copy)
-        }
-      } else {
-        if (!err) {
-          err = {
-            name: 'DuplicatePrimaryKey',
-            message: `Unable to create model '${_this.modelId}' because ${JSON.stringify(whereProperties)} already exists`
-          }
-        }
+    if (index === -1) {
+      const copy = _.cloneDeep(doc)
+      if (!this.primaryKeyProvided) {
+        copy.id = uuid()
       }
-    }
+      //        copy.created = now
+      //        copy.updated = now
+      copy[CREATED_BY] = this.currentUser()
+      this.data.push(copy)
 
-    if (_.isArray(jsonData)) {
-      jsonData.forEach(
-        function (doc) {
-          createOne(doc)
-        }
-      )
+      return {
+        idProperties: this.extractIdPropertiesFromDoc(copy)
+      }
     } else {
-      createOne(jsonData)
-    }
-
-    if (err) {
-      callback(err)
-    } else {
-      callback(
-        null,
-        {
-          idProperties: idProperties
-        }
+      throw new MemoryModelError(
+        'DuplicatePrimaryKey',
+        `Unable to create model '${this.modelId}' because ${JSON.stringify(whereProperties)} already exists`
       )
     }
   }
@@ -356,6 +333,13 @@ class MemoryModel {
     }
 
     return 0
+  }
+}
+
+class MemoryModelError extends Error {
+  constructor (name, message) {
+    super(message)
+    this.name = name
   }
 }
 

--- a/lib/plugin/components/services/storage/Memory-model.js
+++ b/lib/plugin/components/services/storage/Memory-model.js
@@ -293,13 +293,13 @@ class MemoryModel {
     return index
   }
 
-  update (doc, options, callback = NotSet) {
-    if (callback === NotSet) {
-      return this.promised(this.update, doc, options)
+  async update (doc, options, callback = NotSet) {
+    if (callback !== NotSet) {
+      return callbackify(this.update(doc, options), callback)
     }
 
     if (options.setMissingPropertiesToNull === false) {
-      return this.patch(doc, options, callback)
+      return this.patch(doc, options)
     }
 
     const where = this.extractIdPropertiesFromDoc(doc)
@@ -309,7 +309,6 @@ class MemoryModel {
       update[MODIFIED_BY] = this.currentUser()
       this.data[index] = update
     }
-    callback(null)
   }
 
   async patch (doc, options, callback = NotSet) {

--- a/lib/plugin/components/services/storage/Memory-model.js
+++ b/lib/plugin/components/services/storage/Memory-model.js
@@ -8,6 +8,12 @@ require('underscore-query')(_)
 
 const NotSet = 'NetSet'
 
+function callbackify (promise, callback) {
+  promise
+    .then(result => callback(null, result))
+    .catch(err => callback(err))
+}
+
 function promised (obj, fn, ...args) {
   return new Promise((resolve, reject) => {
     fn.call(obj, ...args, (err, result) => {
@@ -346,12 +352,12 @@ class MemoryModel {
     }
   }
 
-  destroyById (id, callback = NotSet) {
-    if (callback === NotSet) {
-      return this.promised(this.destroyById, id)
+  async destroyById (id, callback = NotSet) {
+    if (callback !== NotSet) {
+      return callbackify(this.destroyById(id), callback)
     }
 
-    if (!_.isArray(id)) {
+    if (!Array.isArray(id)) {
       id = [id]
     }
 
@@ -362,7 +368,7 @@ class MemoryModel {
       this.data.splice(index, 1)
     }
 
-    callback(null, 0)
+    return 0
   }
 }
 

--- a/lib/plugin/components/services/storage/Memory-model.js
+++ b/lib/plugin/components/services/storage/Memory-model.js
@@ -312,9 +312,9 @@ class MemoryModel {
     callback(null)
   }
 
-  patch (doc, options, callback = NotSet) {
-    if (callback === NotSet) {
-      return this.promised(this.patch, doc, options)
+  async patch (doc, options, callback = NotSet) {
+    if (callback !== NotSet) {
+      return callbackify(this.patch(doc, options), callback)
     }
 
     const where = this.extractIdPropertiesFromDoc(doc)
@@ -325,7 +325,6 @@ class MemoryModel {
       }
       this.data[index][MODIFIED_BY] = this.currentUser()
     }
-    callback(null)
   }
 
   async upsert (doc, options, callback = NotSet) {

--- a/test/memory-model-promise-spec.js
+++ b/test/memory-model-promise-spec.js
@@ -99,13 +99,8 @@ describe('Memory Model promise tests', function () {
       {}
     )
       .then(() => assert(false))
-      .catch(err => {
-        expect(err).to.containSubset(
-          {
-            name: 'DuplicatePrimaryKey'
-          }
-        )
-      }
+      .catch(err =>
+        expect(err.name).to.eql('DuplicatePrimaryKey')
       )
   })
 
@@ -121,13 +116,8 @@ describe('Memory Model promise tests', function () {
       {}
     )
       .then(() => assert(false))
-      .catch(err => {
-        expect(err).to.containSubset(
-          {
-            name: 'DuplicatePrimaryKey'
-          }
-        )
-      }
+      .catch(err =>
+        expect(err.name).to.eql('DuplicatePrimaryKey')
       )
   })
 

--- a/test/memory-storage-spec.js
+++ b/test/memory-storage-spec.js
@@ -115,12 +115,7 @@ describe('Memory storage tests', function () {
         {},
         function (err) {
           console.log(err)
-          expect(err).to.eql(
-            {
-              name: 'DuplicatePrimaryKey',
-              message: 'Unable to create model \'people\' because {"employeeNo":"1"} already exists'
-            }
-          )
+          expect(err.name).to.eql('DuplicatePrimaryKey')
           done()
         }
       )
@@ -143,12 +138,7 @@ describe('Memory storage tests', function () {
         ],
         {},
         function (err) {
-          expect(err).to.eql(
-            {
-              name: 'DuplicatePrimaryKey',
-              message: 'Unable to create model \'people\' because {"employeeNo":"2"} already exists'
-            }
-          )
+          expect(err.name).to.eql('DuplicatePrimaryKey')
           done()
         }
       )


### PR DESCRIPTION
Switch memory model implementation to use promises rather than callbacks. 

(In practice, memory model is entirely synchronous, but this change brings it into line with pg-model and paves the way to remove the callback interface in the future.)